### PR TITLE
Add interface type to KeystoneV3Authenticator credentials

### DIFF
--- a/KeystoneV3Authenticator.js
+++ b/KeystoneV3Authenticator.js
@@ -12,6 +12,10 @@ class KeystoneV3Authenticator extends EventEmitter {
   }
 
   tryFindEndpointUrl(catalog, service, iface) {
+    if (typeof iface === 'undefined') {
+      iface = "public";
+    }
+
     const catalogEntry = catalog.find(x => x.name === service);
     if (!catalogEntry) {
       return null;
@@ -67,8 +71,8 @@ class KeystoneV3Authenticator extends EventEmitter {
 
     const catalog = response.body.token.catalog;
     const swiftUrl =
-      this.tryFindEndpointUrl(catalog, 'swift', 'public')
-      || this.tryFindEndpointUrl(catalog, 'radosgw-swift', 'public'); // many OpenStack clouds use ceph radosgw to provide swift
+      this.tryFindEndpointUrl(catalog, 'swift', credentials.endpointUrlInterface)
+      || this.tryFindEndpointUrl(catalog, 'radosgw-swift', credentials.endpointUrlInterface); // many OpenStack clouds use ceph radosgw to provide swift
 
     if (!swiftUrl) {
       throw new Error('could not find swift or radosgw-swift service in catalog');

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ let credentials = {
   "username": "user",
   "password": "pasword",
   "domainId": "e6efe92d05c2430ea7eb6f626815d0d8",
-  "projectId": "ff912d95d2eb46099e755cd268714d37"
+  "projectId": "ff912d95d2eb46099e755cd268714d37",
+  "endpointUrlInterface": "public" // admin, internal or public. Value default: public
 }
 
 let client = new SwiftClient(new SwiftClient.KeystoneV3Authenticator(credentials));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openstack-swift-client",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openstack-swift-client",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Connects to OpenStack Swift storage servers",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Included the **"endpointUrlInterface"** attribute in the **"credentials"** object to define which endpoint interface to use. By default the value **"public"** will be used, keeping the behavior already exist if this attribute is not entered.

In the application I'm developing, we use the **"admin"** interface endpoint to manipulate objects in containers (swift).